### PR TITLE
sdata: Use sdk v0.151.0 and update imports to dataplane repo

### DIFF
--- a/sdata/go.mod
+++ b/sdata/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/grafana/grafana-plugin-sdk-go v0.150.0
+	github.com/grafana/grafana-plugin-sdk-go v0.151.0
 	github.com/stretchr/testify v1.8.2
 )
 
@@ -16,6 +16,7 @@ require (
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.13.1 // indirect
+	github.com/magefile/mage v1.14.0 // indirect
 	github.com/mattetti/filebuffer v1.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/sdata/go.sum
+++ b/sdata/go.sum
@@ -68,6 +68,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grafana/grafana-plugin-sdk-go v0.150.0 h1:OvZY8sQnisqHCRNJxYnyptcXc7EskJfeogJmapmurdo=
 github.com/grafana/grafana-plugin-sdk-go v0.150.0/go.mod h1:4f/8Gf6xMwqXhOmS5U2RPmKQ2UgyA0bVteM/gxGFaCI=
+github.com/grafana/grafana-plugin-sdk-go v0.151.0 h1:oaZ2ZBt27teHzSj0leo9o35lDgVtL/QLPNzRLUljdbc=
+github.com/grafana/grafana-plugin-sdk-go v0.151.0/go.mod h1:4f/8Gf6xMwqXhOmS5U2RPmKQ2UgyA0bVteM/gxGFaCI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -75,6 +77,8 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
 github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mattetti/filebuffer v1.0.1 h1:gG7pyfnSIZCxdoKq+cPa8T0hhYtD9NxCdI4D7PTjRLM=
 github.com/mattetti/filebuffer v1.0.1/go.mod h1:YdMURNDOttIiruleeVr6f56OrMc+MydEnTcXwtkxNVs=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=

--- a/sdata/numeric/long.go
+++ b/sdata/numeric/long.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 const FrameTypeNumericLong = "numeric_long"

--- a/sdata/numeric/multi.go
+++ b/sdata/numeric/multi.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 type MultiFrame []*data.Frame

--- a/sdata/numeric/numeric.go
+++ b/sdata/numeric/numeric.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 type CollectionWriter interface {

--- a/sdata/numeric/numeric_test.go
+++ b/sdata/numeric/numeric_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/numeric"
+	"github.com/grafana/dataplane/sdata/numeric"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sdata/numeric/wide.go
+++ b/sdata/numeric/wide.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 const FrameTypeNumericWide = "numeric_wide"

--- a/sdata/reader/play_test.go
+++ b/sdata/reader/play_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/numeric"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/reader"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/timeseries"
+	"github.com/grafana/dataplane/sdata/numeric"
+	"github.com/grafana/dataplane/sdata/reader"
+	"github.com/grafana/dataplane/sdata/timeseries"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sdata/reader/reader.go
+++ b/sdata/reader/reader.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/numeric"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/timeseries"
+	"github.com/grafana/dataplane/sdata"
+	"github.com/grafana/dataplane/sdata/numeric"
+	"github.com/grafana/dataplane/sdata/timeseries"
 )
 
 func supportedTypes() map[data.FrameType]map[data.FrameTypeVersion]struct{} {

--- a/sdata/timeseries/long.go
+++ b/sdata/timeseries/long.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 // LongFrame is a time series format where all series live in one frame.

--- a/sdata/timeseries/long_test.go
+++ b/sdata/timeseries/long_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/timeseries"
+	"github.com/grafana/dataplane/sdata/timeseries"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sdata/timeseries/multi.go
+++ b/sdata/timeseries/multi.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 // MultiFrame is a time series format where each series lives in its own single frame.

--- a/sdata/timeseries/multi_test.go
+++ b/sdata/timeseries/multi_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/timeseries"
+	"github.com/grafana/dataplane/sdata"
+	"github.com/grafana/dataplane/sdata/timeseries"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sdata/timeseries/series.go
+++ b/sdata/timeseries/series.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 type CollectionReader interface {

--- a/sdata/timeseries/series_test.go
+++ b/sdata/timeseries/series_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/timeseries"
+	"github.com/grafana/dataplane/sdata/timeseries"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sdata/timeseries/util.go
+++ b/sdata/timeseries/util.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 func emptyFrameWithTypeMD(refID string, t data.FrameType, v data.FrameTypeVersion) *data.Frame {

--- a/sdata/timeseries/wide.go
+++ b/sdata/timeseries/wide.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
+	"github.com/grafana/dataplane/sdata"
 )
 
 // WideFrame is a time series format where all the series live in one frame.

--- a/sdata/timeseries/wide_test.go
+++ b/sdata/timeseries/wide_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata/timeseries"
+	"github.com/grafana/dataplane/sdata/timeseries"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
https://github.com/grafana/grafana-plugin-sdk-go/releases/tag/v0.151.0 which includes the FieldTypeFor changes (this issue with []*float64)

Also update the self module imports not to reference sdata in the sdk repo.