### PR TITLE
allow passing field config to time series wide addSeries

### DIFF
--- a/sdata/timeseries/series_test.go
+++ b/sdata/timeseries/series_test.go
@@ -55,10 +55,10 @@ func TestSeriesCollectionReaderInterface(t *testing.T) {
 		err = sc.SetTime("time", timeSlice)
 		require.NoError(t, err)
 
-		err = sc.AddSeries(metricName, data.Labels{"host": "a"}, valuesA)
+		err = sc.AddSeries(metricName, valuesA, data.Labels{"host": "a"}, nil)
 		require.NoError(t, err)
 
-		err = sc.AddSeries(metricName, data.Labels{"host": "b"}, valuesB)
+		err = sc.AddSeries(metricName, valuesB, data.Labels{"host": "b"}, nil)
 		require.NoError(t, err)
 
 		var r timeseries.CollectionReader = sc

--- a/sdata/timeseries/wide.go
+++ b/sdata/timeseries/wide.go
@@ -54,7 +54,7 @@ func (wf *WideFrame) SetTime(timeName string, t []time.Time) error {
 	return nil
 }
 
-func (wf *WideFrame) AddSeries(metricName string, l data.Labels, values interface{}) error {
+func (wf *WideFrame) AddSeries(metricName string, values interface{}, l data.Labels, config *data.FieldConfig) error {
 	if !data.ValidFieldType(values) {
 		return fmt.Errorf("type %T is not a valid data frame field type", values)
 	}
@@ -85,6 +85,8 @@ func (wf *WideFrame) AddSeries(metricName string, l data.Labels, values interfac
 		return fmt.Errorf("value field length must match time field length, but got length %v for time and %v for values",
 			frame.Fields[0].Len(), valueField.Len())
 	}
+
+	valueField.Config = config
 
 	frame.Fields = append(frame.Fields, valueField)
 

--- a/sdata/timeseries/wide_test.go
+++ b/sdata/timeseries/wide_test.go
@@ -18,10 +18,10 @@ func TestWideFrameAddMetric_ValidCases(t *testing.T) {
 		err = wf.SetTime("time", []time.Time{time.UnixMilli(1), time.UnixMilli(2)})
 		require.NoError(t, err)
 
-		err = wf.AddSeries("one", data.Labels{"host": "a"}, []float64{1, 2})
+		err = wf.AddSeries("one", []float64{1, 2}, data.Labels{"host": "a"}, nil)
 		require.NoError(t, err)
 
-		err = wf.AddSeries("one", data.Labels{"host": "b"}, []float64{3, 4})
+		err = wf.AddSeries("one", []float64{3, 4}, data.Labels{"host": "b"}, nil)
 		require.NoError(t, err)
 
 		expectedFrame := data.NewFrame("",
@@ -46,10 +46,10 @@ func TestWideFrameSeriesGetMetricRefs(t *testing.T) {
 		err = wf.SetTime("time", []time.Time{time.UnixMilli(1), time.UnixMilli(2)})
 		require.NoError(t, err)
 
-		err = wf.AddSeries("one", data.Labels{"host": "a"}, []float64{1, 2})
+		err = wf.AddSeries("one", []float64{1, 2}, data.Labels{"host": "a"}, nil)
 		require.NoError(t, err)
 
-		err = wf.AddSeries("one", data.Labels{"host": "b"}, []float64{3, 4})
+		err = wf.AddSeries("one", []float64{3, 4}, data.Labels{"host": "b"}, nil)
 		require.NoError(t, err)
 
 		c, err := wf.GetCollection(false)


### PR DESCRIPTION
This PR adds option to pass field config when calling AddSeries method in wide timeseries.
