### PR TITLE
update github actions for website

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: ./docusaurus/website/build
-          user_name: grafanabot
-          user_email: bot@grafana.com


### PR DESCRIPTION
previous attempt to publish pages failed to incorrect access. https://github.com/grafana/dataplane/actions/runs/4949113456/jobs/8850777105

updating with new token.