### PR TITLE
Contract docs: Table contract

### DIFF
--- a/docs/contract/contract.md
+++ b/docs/contract/contract.md
@@ -27,6 +27,9 @@ A **_data type_** definition or declaration in this framework includes both a ki
   - [Sparse](./heatmap.md#heatmap-sparse-heatmapsparse)
 - [Logs](./logs.md)
   - [LogLines](./logs.md#loglines)
+- [Table](./table.md)
+  - [TablePlain](./table.md#tableplain-format)
+  - [TableFrame](./table.md#tableframe-format)
 
 ## Dimensional Set Based Kinds
 

--- a/docs/contract/table.md
+++ b/docs/contract/table.md
@@ -1,0 +1,45 @@
+# Table Kind
+
+Status: EARLY Draft/Proposal
+
+If a dataframe doesn't fit other contract, that will be considered as table kind contract. Following formats fall under the table kind contract.
+
+- Table Plain
+- Table Frame
+
+## TablePlain Format
+
+Version: 0.0
+
+### Definition
+
+This format is default contract for the table kind. This contract is mostly like SQL tables.
+
+### Properties
+
+- By default, it is single frame. If multiple frames present, all frame names have to be unique
+- All field names must be unique to its frame. (No duplicate field names allowed within the frame)
+- All the labels will be ignored
+
+### Example
+
+Following is an example of a table plain kind
+
+| Name: User Name<br/>Type: []string<br/>Label: `nil` | Name: Country<br/>Type: []\*string<br/>Label: `nil` | Name: Age<br/>Type: []string<br/>Label: `nil` | Name: Is Employee<br/>Type: []boolean<br/>Label: `nil` |
+| --------------------------------------------------- | --------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------ |
+| Foo                                                 | India                                               | 27                                            | false                                                  |
+| Bar                                                 | USA                                                 | 35                                            | true                                                   |
+
+## TableFrame Format
+
+Version: 0.0
+
+### Definition
+
+This is the default fallback format for all the formats+kind.
+
+### Properties
+
+- There can be multiple frames
+- Field name can be duplicate within frame. If duplicate field names found, they must be distinguished by labels
+- Fields can have labels

--- a/docusaurus/website/sidebars.js
+++ b/docusaurus/website/sidebars.js
@@ -8,6 +8,7 @@ const sidebars = {
       { id: "numeric", label: "Numeric", type: "doc" },
       { id: "logs", label: "Logs", type: "doc" },
       { id: "heatmap", label: "Heatmap", type: "doc" },
+      { id: "table", label: "Table", type: "doc" },
     ],
   },
 };


### PR DESCRIPTION
This PR adds proposal for table kind contract with two formats ( table plain and table frame ).

## Why this is required

If a data frame doesn't falls under `timeseries`, `numeric` or any other known kinds, By specifying this as **table** kind will let the consumers know how to handle it without any guess work. Say example, when a frame have three fields ( `date-of-birth (time)`, `name(string)` and `age(number)` ), it can be easily misinterpreted either as `timeseries` or `numeric`. So by specifying **table** kind, consumers can handle this without confusion.

## Why two different formats

This PR proposes two different format (`table plain` and `table frame` ) under `table` kind.  

By specifying `table plain` it will become clear that the consumer doesn't need to handle any fields. This format can simply act like a sql table/database.

By specifying `table frame` it will become clear that the data is not timeseries/numeric or any other known formats. Also it is clear that the data require some post processing due to the presence of labels.

Looking for feedback.