### PR TITLE
Adding developer portal dev workflow and config

### DIFF
--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -1,0 +1,48 @@
+name: Deploy to Developer Portal DEV Bucket
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Which branch to use?"
+        default: "main"
+jobs:
+  deploy:
+    name: Deploy docs to Developer Portal Bucket
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable --prefer-offline
+      
+        #mac: sed -i '' 's/title: Data Plane Contract - Technical Specification/title: Data Plane Contract - Technical Specification\nslug:\ \//g' ./docs/contract/contract.md
+        #linux: sed -i 's/title: Data Plane Contract - Technical Specification/title: Data Plane Contract - Technical Specification\nslug:\ \//g' ./docs/contract/contract.md
+      - name: Make docs the homepage of this subsite
+        run: |
+          rm -f ./docusaurus/website/src/pages/index.tsx
+          sed -i 's/title: Data Plane Contract - Technical Specification/title: Data Plane Contract - Technical Specification\nslug:\ \//g' ./docs/contract/contract.md
+            
+      - name: Build documentation website
+        run: yarn docs:build:devportal
+          
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
+      - name: Deploy to Developer Portal Bucket
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: './docusaurus/website/build/'
+          destination: 'grafana_developer_portal/dataplane'
+          parent: false

--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -44,5 +44,5 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: './docusaurus/website/build/'
-          destination: 'grafana_developer_portal/dataplane'
+          destination: 'staging-developer-portal/dataplane'
           parent: false

--- a/docusaurus/website/docusaurus.config.devportal.js
+++ b/docusaurus/website/docusaurus.config.devportal.js
@@ -1,0 +1,135 @@
+// @ts-check
+// Note: type annotations allow type checking and IDEs autocompletion
+
+const lightCodeTheme = require("prism-react-renderer/themes/github");
+const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+// const remark = require("remark");
+// const stripHTML = require("remark-strip-html");
+
+/** @type {import('@docusaurus/types').Config} */
+const config = {
+  title: "Grafana Data Plane",
+  tagline: "A contract of data types as the source of truth",
+  url: "https://grafana-dev.com/",
+  baseUrl: "developers/dataplane/",
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "warn",
+  favicon: "img/favicon.png",
+  organizationName: "grafana",
+  projectName: "dataplane",
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en"],
+  },
+  plugins: [],
+  presets: [
+    [
+      "classic",
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
+        docs: {
+          routeBasePath: "/",
+          path: "../../docs/contract",
+          sidebarPath: require.resolve("./sidebars.js"),
+          // Please change this to your repo.
+          // Remove this to remove the "edit this page" links.
+          editUrl:
+            "https://github.com/grafana/dataplane/edit/main/docusaurus/website",
+        },
+        theme: {
+          customCss: require.resolve("./src/css/custom.css"),
+        },
+        blog: false,
+      }),
+    ],
+  ],
+
+  themeConfig:
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    ({
+      navbar: {
+        title: "Grafana Data Plane",
+        logo: {
+          alt: "Grafana Logo",
+          src: "img/logo.svg",
+        },
+        items: [
+          {
+            type: "doc",
+            docId: "contract",
+            position: "right",
+            label: "Contract",
+          },
+          {
+            href: "https://www.github.com/grafana/dataplane",
+            label: "GitHub",
+            position: "right",
+          },
+        ],
+      },
+      footer: {
+        style: "dark",
+        links: [
+          {
+            title: "Docs",
+            items: [
+              {
+                label: "Contract",
+                to: "/",
+              },
+            ],
+          },
+          {
+            title: "Tools & Examples",
+            items: [
+              {
+                label: "Mock Data Source Plugin",
+                href: "https://grafana.com/plugins/grafana-mock-datasource",
+              },
+              {
+                label: "Example Data Frames (JSON)",
+                href: "https://github.com/grafana/dataplane/tree/main/examples/data",
+              },
+              {
+                label: "Go Testing/Example Library",
+                href: "https://pkg.go.dev/github.com/grafana/dataplane/examples",
+              },
+              {
+                label: "Go Dataplane Library",
+                href: "https://pkg.go.dev/github.com/grafana/dataplane/sdata",
+              },
+            ],
+          },
+          {
+            title: "Other Resources",
+            items: [
+              {
+                label: "Go Plugin Data Package",
+                href: "hhttps://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data",
+              }
+            ],
+          },
+          {
+            title: "Community",
+            items: [
+              {
+                label: "GitHub",
+                href: "https://www.github.com/grafana/dataplane",
+              },
+              {
+                label: "Github Issues",
+                href: "https://www.github.com/grafana/dataplane/issues",
+              },
+            ],
+          },
+        ],
+        copyright: `Copyright © ${new Date().getFullYear()} Grafana Labs. Built with Docusaurus.`,
+      },
+      prism: {
+        theme: lightCodeTheme,
+        darkTheme: darkCodeTheme,
+      },
+    }),
+};
+
+module.exports = config;


### PR DESCRIPTION
This PR:
- Adds a github action that deploys dataplane docusaurus content into dev portal dev bucket, triggered manually
- Adds a docusaurus config necessary to remove the landing page so it can work from a subdirectory 

We will simplify the docusaurus configs later once production deployment is in place