### PR TITLE
Website: add search plugin to production config

### DIFF
--- a/docusaurus/website/docusaurus.config.devportal.prod.js
+++ b/docusaurus/website/docusaurus.config.devportal.prod.js
@@ -20,7 +20,14 @@ const config = {
     defaultLocale: "en",
     locales: ["en"],
   },
-  plugins: [],
+  plugins: [
+    [
+      "docusaurus-lunr-search",
+      {
+        disableVersioning: true,
+      },
+    ],
+  ],
   presets: [
     [
       "classic",


### PR DESCRIPTION
I missed adding the search plugin to the docusaurus prod config. 🤦 