### PR TITLE
Logs: Update dataplane specification to have labels field instead of attributes

### DIFF
--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -24,7 +24,7 @@ Version: 0.0
   - Unique identifier of the log line
 - **Labels field** - _optional_
   - The first field with the name `labels` is the labels field.
-  - This field represent additional labels of the log line.
+  - This field represents additional information about the log line.
   - Field type must be json raw message type. Example value: `{}`, `{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`
     - Value should be represented with `Record<string,any>` type in javascript.
 

--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -22,15 +22,13 @@ Version: 0.0
 - **ID field** - _optional_
   - The first string field with the name `id` is the id field.
   - Unique identifier of the log line
-- **Attributes field** - _optional_
-  - The first string field with the name `attributes` is the attributes field.
-  - Other systems may refer to this with other names, for example Loki calls these "labels"
-  - This field represent additional attributes of the log line.
+- **Labels field** - _optional_
+  - The first field with the name `labels` is the labels field.
+  - This field represent additional labels of the log line.
   - Field type must be json raw message type. Example value: `{}`, `{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`
-    - Should not be empty string.
     - Value should be represented with `Record<string,any>` type in javascript.
 
-Any other field is ignored.
+Any other field is ignored by logs visualisation.
 
 ### Example
 
@@ -43,13 +41,13 @@ data.NewFrame(
     data.NewField("body", nil, []string{"message one", "message two", "message three"}),
     data.NewField("severity", nil, []string{"critical", "error", "warning"}),
     data.NewField("id", nil, []string{"xxx-001", "xyz-002", "111-003"}),
-    data.NewField("attributes", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"world"}`), []byte(`{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`)}),
+    data.NewField("labels", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"world"}`), []byte(`{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`)}),
 )
 ```
 
 the same can be represented as
 
-| Name: timestamp <br/> Type: []time.Time | Name: body <br/> Type: []string | Name: severity <br/> Type: []\*string | Name: id <br/> Type: []\*string | Name: attributes <br/> Type: []json.RawMessage                                         |
+| Name: timestamp <br/> Type: []time.Time | Name: body <br/> Type: []string | Name: severity <br/> Type: []\*string | Name: id <br/> Type: []\*string | Name: labels <br/> Type: []json.RawMessage                                         |
 | --------------------------------------- | ------------------------------- | ------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------- |
 | 2022-02-16 16:50:44.810 +0000 GMT       | message one                     | critical                              | xxx-001                         | {}                                                                                     |
 | 2022-02-16 16:50:47.027 +0000 GMT       | message two                     | error                                 | xyz-002                         | {"hello":"world"}                                                                      |


### PR DESCRIPTION
Based on the discussion where we agreed that `labels` is a better option for a name of field in logs data plane format than `attributes`. This is because it helps us with backward compatibility and makes it easier for plugin developers to create logs data source plugins that correctly visualise logs in older versions of Grafana. 

Part of https://github.com/grafana/grafana/issues/77697