### PR TITLE
Move footnotes into the table as inline notes

### DIFF
--- a/docs/contract/timeseries.md
+++ b/docs/contract/timeseries.md
@@ -295,7 +295,6 @@ Additional Properties or Considerations:
          <ul>
             <li>One Frame to multiple Frames</li>
             <li>Each value (numeric) field alongside a copy of the time field from the Wide Frame is moved to its own individual Frame when converted to the Multi format</li>
-            <li><em><sup>*</sup>Of the time series format, only when the format being converted to is "Multi" can the underlying time series data not be manipulated</em></li>
          </ul>
       </td>
    </tr>
@@ -321,7 +320,6 @@ Additional Properties or Considerations:
             <li>One Frame to one Frame</li>
             <li>Labels are extracted from the value Fields, and become string Fields with a name that matches all the keys found in all labels. The label values become Field values in the corresponding fields.</li>
             <li>Because the string field will be present, label/dimension keys that exist for one series must exist for all the series, and therefore the series may be altered in that label keys that did not exist are created (likely with a value of null). This effectively may create series that didn't exist</li>
-            <li><em><sup>†</sup>In practice, I haven't seen any cases for converting to the Long format, only reading it in. Perhaps it may be requested as an export format at some point, but basically this is for illustration presently.</em></li>
          </ul>
       </td>
    </tr>
@@ -335,7 +333,6 @@ Additional Properties or Considerations:
             <li>String Fields become labels on the value (numeric) fields (label keys come from Field name, label values from the Field's values.</li>
             <li>Repeated timestamps in a single time field from the Long frame are de-duplicated in the time field in the Wide Frame</li>
             <li>Because rows (timestamps) may be missing in the data of Long format, nulls may need to be inserted into the series to make them all share the same time field (a property of Wide)</li>
-            <li><em><sup>‡</sup>This is used by the SQL datasources to extract time series from the "Long" format (via go sdk/data pkg). In hindsight I sort of wish we had gone with LongToMany instead. See "related" in <a href="https://github.com/grafana/grafana-plugin-sdk-go/issues/315#issuecomment-817839070">this issue comment</a>.</em></li>
          </ul>
       </td>
    </tr>
@@ -365,6 +362,10 @@ Additional Properties or Considerations:
 <!-- Footnotes themselves at the bottom. -->
 
 ## Notes
+
+<p><sup>*</sup>Of the time series format, only when the format being converted to is "Multi" can the underlying time series data not be manipulated</p>
+<p><sup>†</sup>In practice, I haven't seen any cases for converting to the Long format, only reading it in. Perhaps it may be requested as an export format at some point, but basically this is for illustration presently.</p>
+<p><sup>‡</sup>This is used by the SQL datasources to extract time series from the "Long" format (via go sdk/data pkg). In hindsight I sort of wish we had gone with LongToMany instead. See "related" in <a href="https://github.com/grafana/grafana-plugin-sdk-go/issues/315#issuecomment-817839070">this issue comment</a>.</p>
 
 [^1]: This is because sorting is generally expensive in terms of resources, and is best done by the database behind a datasource in most cases.
 [^2]: I don't believe our current SQL datasources strictly follow this, but some Azure ones do. This was either due to miscommunication about the intent of this format and the upgrade to Grafana 8 and/or lack of understanding about breaking changes, or both.

--- a/docs/contract/timeseries.md
+++ b/docs/contract/timeseries.md
@@ -284,17 +284,18 @@ Additional Properties or Considerations:
          <strong>Modifies Data</strong>
       </td>
       <td>
-         <strong>Properties</strong>
+         <strong>Properties and <em>Notes</em></strong>
       </td>
    </tr>
    <tr>
       <td>Wide</td>
       <td>Multi</td>
-      <td><strong>No</strong>[^6]</td>
+      <td><strong>No<sup>*</sup></strong></td>
       <td>
          <ul>
             <li>One Frame to multiple Frames</li>
             <li>Each value (numeric) field alongside a copy of the time field from the Wide Frame is moved to its own individual Frame when converted to the Multi format</li>
+            <li><em><sup>*</sup>Of the time series format, only when the format being converted to is "Multi" can the underlying time series data not be manipulated</em></li>
          </ul>
       </td>
    </tr>
@@ -313,26 +314,28 @@ Additional Properties or Considerations:
    </tr>
    <tr>
       <td>Wide</td>
-      <td><em>Long</em>[^7]</td>
+      <td><em>Long<sup>†</sup></em></td>
       <td>Yes</td>
       <td>
          <ul>
             <li>One Frame to one Frame</li>
             <li>Labels are extracted from the value Fields, and become string Fields with a name that matches all the keys found in all labels. The label values become Field values in the corresponding fields.</li>
             <li>Because the string field will be present, label/dimension keys that exist for one series must exist for all the series, and therefore the series may be altered in that label keys that did not exist are created (likely with a value of null). This effectively may create series that didn't exist</li>
+            <li><em><sup>†</sup>In practice, I haven't seen any cases for converting to the Long format, only reading it in. Perhaps it may be requested as an export format at some point, but basically this is for illustration presently.</em></li>
          </ul>
       </td>
    </tr>
    <tr>
       <td>Long</td>
       <td>Wide</td>
-      <td>Yes[^8]</td>
+      <td>Yes<sup>‡</sup></td>
       <td>
          <ul>
             <li>One Frame to One Frame</li>
             <li>String Fields become labels on the value (numeric) fields (label keys come from Field name, label values from the Field's values.</li>
             <li>Repeated timestamps in a single time field from the Long frame are de-duplicated in the time field in the Wide Frame</li>
             <li>Because rows (timestamps) may be missing in the data of Long format, nulls may need to be inserted into the series to make them all share the same time field (a property of Wide)</li>
+            <li><em><sup>‡</sup>This is used by the SQL datasources to extract time series from the "Long" format (via go sdk/data pkg). In hindsight I sort of wish we had gone with LongToMany instead. See "related" in <a href="https://github.com/grafana/grafana-plugin-sdk-go/issues/315#issuecomment-817839070">this issue comment</a>.</em></li>
          </ul>
       </td>
    </tr>
@@ -363,9 +366,6 @@ Additional Properties or Considerations:
 
 ## Notes
 
-[^3]: This is because sorting is generally expensive in terms of resources, and is best done by the database behind a datasource in most cases.
-[^4]: I don't believe our current SQL datasources strictly follow this, but some Azure ones do. This was either due to miscommunication about the intent of this format and the upgrade to Grafana 8 and/or lack of understanding about breaking changes, or both.
-[^5]: This transformation happens when queried with "Format As=Time Series". The problem with the transformation happening at this stage of the pipeline is that while it does give the user Time Series for a common Time Series in Table format, it makes it so the "Table View" of the data doesn't like up with SQL returns from their query. **TODO: Define this general concept later, maybe call it "What you see is _NOT_ what you get", "Data Miscommunication", something.** This means we either need to return two things (sort of like exemplars?), or the operation should be moved, or something else.
-[^6]: Of the time series format, only when the format being converted to is "Multi" can the underlying time series data not be manipulated
-[^7]: In practice, I haven't seen any cases for converting to the Long format, only reading it in. Perhaps it may be requested as an export format at some point, but basically this is for illustration presently.
-[^8]: This is used by the SQL datasources to extract time series from the "Long" format (via go sdk/data pkg). In hindsight I sort of wish we had gone with LongToMany instead. See "related" in <a href="https://github.com/grafana/grafana-plugin-sdk-go/issues/315#issuecomment-817839070">this issue comment</a>.
+[^1]: This is because sorting is generally expensive in terms of resources, and is best done by the database behind a datasource in most cases.
+[^2]: I don't believe our current SQL datasources strictly follow this, but some Azure ones do. This was either due to miscommunication about the intent of this format and the upgrade to Grafana 8 and/or lack of understanding about breaking changes, or both.
+[^3]: This transformation happens when queried with "Format As=Time Series". The problem with the transformation happening at this stage of the pipeline is that while it does give the user Time Series for a common Time Series in Table format, it makes it so the "Table View" of the data doesn't like up with SQL returns from their query. **TODO: Define this general concept later, maybe call it "What you see is _NOT_ what you get", "Data Miscommunication", something.** This means we either need to return two things (sort of like exemplars?), or the operation should be moved, or something else.


### PR DESCRIPTION
Fixes #46

There's a limitation in Markdown that footnotes such as `[^6]` cannot
be rendered when found within table cells. So the last three footnotes are
entirely broken.
They look like this in the body:

<img width="180" alt="Screenshot 2024-10-14 at 22 08 00" src="https://github.com/user-attachments/assets/e02fb755-44fe-4e41-9627-b031a1b8a4a9">

And this at the footer (ie. they are missing):

<img width="200" alt="image" src="https://github.com/user-attachments/assets/4bfa2ef7-b50e-49c3-a672-78a3a72bd1ae">



Perplexity AI tells me that
this is not possible, and gives a few possible reasons:
https://www.perplexity.ai/search/why-can-t-i-use-markdown-footn-L.TQdIMSSmeCn4QugvC8tw#0

Rather than have these completely broken, I figured we should render
them properly. This is what I found which I considered to be a
reasonable solution.

In the process I also figured I should fix the references for the first
three footnotes on this page at the same time.

The notes now look like this, when I run `yarn docs` locally:

<img width="100" alt="image" src="https://github.com/user-attachments/assets/e345d7f8-d305-4d4b-935c-c42bbd7a440e"> and <img width="100" alt="image" src="https://github.com/user-attachments/assets/4e19b7fc-30e9-42b1-83e2-019279db89fa">

**EDIT** Since the PR review, they now look like this:

See the notes which were broken before rendered immediately after the **Notes** heading, and before the numbered footnotes.

![image](https://github.com/user-attachments/assets/7ed405e9-46a1-454e-9f98-f228493d44b5)
