### PR TITLE
Moving to rsync

### DIFF
--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -44,4 +44,4 @@ jobs:
        
       - name: 'Deploy to Developer Portal Bucket'
         run: |
-          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://staging-developer-portal/dataplane
+          gsutil -m rsync -r -d -c ./docusaurus/website/build/ gs://staging-developer-portal/dataplane

--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -12,22 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable --prefer-offline
       
-        #mac: sed -i '' '1s/^/---\nslug: \/\n---\n/' ./docs/contract/contract.md
-        #linux: sed -i '1s/^/---\nslug: \/\n---\n/' ./docs/contract/contract.md
       - name: Make docs the homepage of this subsite
         run: |
           rm -f ./docusaurus/website/src/pages/index.tsx
@@ -37,12 +35,13 @@ jobs:
         run: yarn docs:build:devportal:dev
           
       - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
-      - name: Deploy to Developer Portal Bucket
-        uses: google-github-actions/upload-cloud-storage@v1
-        with:
-          path: './docusaurus/website/build/'
-          destination: 'staging-developer-portal/dataplane'
-          parent: false
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+       
+      - name: 'Deploy to Developer Portal Bucket'
+        run: |
+          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://staging-developer-portal/dataplane

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -46,4 +46,4 @@ jobs:
        
       - name: 'Deploy to Developer Portal Bucket'
         run: |
-          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://grafana-developer-portal/dataplane
+          gsutil -m rsync -r -d -c ./docusaurus/website/build/ gs://grafana-developer-portal/dataplane

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -37,12 +37,13 @@ jobs:
         run: yarn docs:build:devportal:prod
           
       - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Deploy to Developer Portal Bucket
-        uses: google-github-actions/upload-cloud-storage@v1
-        with:
-          path: './docusaurus/website/build/'
-          destination: 'grafana-developer-portal/dataplane'
-          parent: false
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+       
+      - name: 'Deploy to Developer Portal Bucket'
+        run: |
+          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://grafana-developer-portal/dataplane

--- a/docs/contract/timeseries.md
+++ b/docs/contract/timeseries.md
@@ -2,7 +2,7 @@
 
 ## Properties Shared by All Time Series Based Formats
 
-- Frames should be sorted by the time column/field in ascending order[^3]
+- Frames should be sorted by the time column/field in ascending order[^1]
 - The Time field(s):
   - Should have no null values
   - Field name is for display purposes only, there should be no labels
@@ -182,7 +182,7 @@ Notes:
 
 Version: 0.1
 
-This is a response format common to SQL like systems[^4]. See [Grafana documentation: Multiple dimensions in table format](https://grafana.com/docs/grafana/latest/basics/timeseries-dimensions/#multiple-dimensions-in-table-format) for some more simple (but not complete) examples. It currently exists as a data transformation within some datasources[^5] in the backend that query SQL-like data, see [this Go Example for how that code works](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data#example-Frame-TableLikeLongTimeSeries).
+This is a response format common to SQL like systems[^2]. See [Grafana documentation: Multiple dimensions in table format](https://grafana.com/docs/grafana/latest/basics/timeseries-dimensions/#multiple-dimensions-in-table-format) for some more simple (but not complete) examples. It currently exists as a data transformation within some datasources[^3] in the backend that query SQL-like data, see [this Go Example for how that code works](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data#example-Frame-TableLikeLongTimeSeries).
 
 The format is called "Long" because there are more rows to hold the same series than the "wide" format and therefore it grows _longer_.
 


### PR DESCRIPTION
Following up on: https://github.com/grafana/scenes/pull/938, https://github.com/grafana/plugin-tools/pull/1214 and https://github.com/grafana/grafana-developer-portal/pull/22

Switching to using rsync with delete option - to ensure that the GCS content equals the content of the build, up until now we just added new files but never deleted the old ones.  Since it is a static site - it can lead to some weird old built pages still being available even when deleted from the source code. This PR cleans it up.

Starting as dry run `-n` and will remove it before merge.

Example run on dev: https://github.com/grafana/dataplane/actions/runs/11343766647/job/31547045488#step:9:1

- [x] Remove dry run for dev
- [x] Remove dry run for prod