### PR TITLE
gha: harden permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions: {}
+
 on:
   pull_request:
   push:
@@ -9,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     name: Run unit tests
+    permissions:
+      contents: read #Clone repo
+      statuses: write # Update GitHub status check with deploy preview link.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          persist-credentials: false
           ref: ${{ github.ref }}
       - name: Install dependencies
         run: yarn install --immutable --prefer-offline

--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -1,4 +1,5 @@
 name: Deploy to Developer Portal DEV Bucket
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -10,12 +11,15 @@ jobs:
   deploy:
     name: Deploy docs to Developer Portal Bucket
     runs-on: ubuntu-latest
+    permissions:
+      contents: read #Clone repo
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -1,4 +1,5 @@
 name: Deploy to Developer Portal PROD Bucket
+permissions: {}
 
 on:
   push:
@@ -12,9 +13,13 @@ jobs:
   deploy:
     name: Deploy docs to Developer Portal Bucket
     runs-on: ubuntu-latest
+    permissions:
+      contents: read #Clone repo
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
```
zizmor dataplane --gh-token $(gh auth token)
 INFO audit: zizmor: 🌈 completed dataplane/.github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed dataplane/.github/workflows/deploy-to-developer-portal-dev.yml
 INFO audit: zizmor: 🌈 completed dataplane/.github/workflows/deploy-to-developer-portal-prod.yml
No findings to report. Good job! (10 suppressed)
```

@kylebrandt I used the [Github Docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) around `permissions` to make a best guess for the needed permissions. 