### PR TITLE
Chore: move to workflow federation

### DIFF
--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -1,5 +1,7 @@
 name: Deploy to Developer Portal DEV Bucket
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -7,6 +9,10 @@ on:
       branch:
         description: "Which branch to use?"
         default: "main"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy docs to Developer Portal Bucket
@@ -23,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -38,10 +44,11 @@ jobs:
       - name: Build documentation website
         run: yarn docs:build:devportal:dev
           
-      - id: 'auth'
-        uses: 'google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193'
+      - uses: grafana/shared-workflows/actions/login-to-gcs@64c35f1dffd024130947f485ed6a150edfe83d22 # v0.2.0
+        id: login-to-gcs
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
+          service_account: 'github-developer-portal-dev@grafanalabs-workload-identity.iam.gserviceaccount.com'
+          bucket: 'staging-developer-portal'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a'

--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -15,13 +15,13 @@ jobs:
       contents: read #Clone repo
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -1,5 +1,7 @@
 name: Deploy to Developer Portal PROD Bucket
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
 
 on:
   push:
@@ -9,6 +11,10 @@ on:
       - ".github/workflows/deploy-to-developer-portal-prod.yml"
       - "docusaurus/**"
       - "docs/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy docs to Developer Portal Bucket
@@ -24,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -41,10 +47,11 @@ jobs:
       - name: Build documentation website
         run: yarn docs:build:devportal:prod
           
-      - id: 'auth'
-        uses: 'google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193'
+      - uses: grafana/shared-workflows/actions/login-to-gcs@64c35f1dffd024130947f485ed6a150edfe83d22 # v0.2.0
+        id: login-to-gcs
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: 'github-developer-portal-dev@grafanalabs-workload-identity.iam.gserviceaccount.com'
+          bucket: 'staging-developer-portal'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a'

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -17,12 +17,12 @@ jobs:
       contents: read #Clone repo
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
This PR moves to using github workflow federation (short lived tokens) instead of secrets.

Once this is merged and working you can delete the `secrets.GCP_SA_KEY_DEV` and `secrets.GCP_SA_KEY` in the repository settings.