### PR TITLE
Fix: prod service account for dev portal deployment

### DIFF
--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -1,5 +1,7 @@
 name: Deploy to Developer Portal DEV Bucket
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -1,5 +1,7 @@
 name: Deploy to Developer Portal PROD Bucket
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
 
 on:
   push:

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -50,8 +50,8 @@ jobs:
       - uses: grafana/shared-workflows/actions/login-to-gcs@64c35f1dffd024130947f485ed6a150edfe83d22 # v0.2.0
         id: login-to-gcs
         with:
-          service_account: 'github-developer-portal-dev@grafanalabs-workload-identity.iam.gserviceaccount.com'
-          bucket: 'staging-developer-portal'
+          service_account: 'github-developer-portal@grafanalabs-workload-identity.iam.gserviceaccount.com'
+          bucket: 'grafana-developer-portal'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a'


### PR DESCRIPTION
Followup on https://github.com/grafana/dataplane/pull/53

Mixed up the service account and bucket name for prod. This PR fixes it.