### PR TITLE
Docs: Data frame info

### DIFF
--- a/docs/contract/contract-spec.md
+++ b/docs/contract/contract-spec.md
@@ -4,13 +4,13 @@ Grafana supports a variety of different data sources, each with its own data mod
 
 ## How is the data plane layer built?
 
-The data plane layer indicates the data frame **type** (for example: time series data, numeric, or a histogram). In turn, the data frame type consists of a **kind** (of data) and the data **format** (Prometheus-like, SQL-table-like). 
+The data plane layer indicates the data frame **type** (for example: time series data, numeric, or a histogram). In turn, the data frame type consists of a **kind** of data (time series, numeric...) and the data **format** (wide, long, multi, Prometheus-like, SQL-table-like...). 
 
 For example, the `TimeSeriesWide` type consists of the kind "Time Series" and the format "Wide".
 
 ## Available data types
 
-The following data types are available:
+The following data frame types are available:
 
 - [Time series](./timeseries.md)
   - [Wide](./timeseries.md#time-series-wide-format-timeserieswide)

--- a/docs/contract/contract-spec.md
+++ b/docs/contract/contract-spec.md
@@ -10,7 +10,7 @@ For example, the `TimeSeriesWide` type consists of the kind "Time Series" and th
 
 ## Available data types
 
-The following types are available:
+The following data types are available:
 
 - [Time series](./timeseries.md)
   - [Wide](./timeseries.md#time-series-wide-format-timeserieswide)

--- a/docs/contract/dataframes.md
+++ b/docs/contract/dataframes.md
@@ -1,5 +1,31 @@
 # Data frames
 
-A data frame is a collection of fields, where each field corresponds to a column. Each field, in turn, consists of a collection of values and metadata, such as the data type of those values. Refer to [Data frames](https://grafana.com/developers/plugin-tools/key-concepts/data-frames) in the Plugins developer documentation for an overview of data frames. 
+A data frame is a collection of fields, where each field corresponds to a column. Each field, in turn, consists of a collection of values and metadata, such as the data type of those values. 
+
+## Work with data frames
+
+Refer to [Data frames](https://grafana.com/developers/plugin-tools/key-concepts/data-frames) in the Plugins developer documentation for an overview of data frames. 
+
+For a guide to plugin development with data frames, refer to [Create data frames](https://grafana.com/developers/plugin-tools/how-to-guides/data-source-plugins/create-data-frames).
+
+## Technical references
+
+Data frames were introduced in Grafana 7.0, replacing the Time series and Table structures with a more generic data structure that can support a wider range of data types. The concept of data frame is borrowed from data analysis tools like the [R programming language](https://www.r-project.org) and [Pandas](https://pandas.pydata.org/). Other technical references are provided below.
+
+### Apache Arrow
+
+The data frame structure is inspired by, and uses the [Apache Arrow Project](https://arrow.apache.org/). Javascript Data frames use Arrow Tables as the underlying structure, and the backend Go code serializes its Frames in Arrow Tables for transmission.
+
+### Javascript
+
+The JavaScript implementation of data frames is in the [`/src/dataframe` folder](https://github.com/grafana/grafana/tree/main/packages/grafana-data/src/dataframe) and [`/src/types/dataframe.ts`](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/dataFrame.ts) of the [`@grafana/data` package](https://github.com/grafana/grafana/tree/main/packages/grafana-data).
+
+### Go
+
+For documentation on the Go implementation of data frames, refer to the [github.com/grafana/grafana-plugin-sdk-go/data package](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data?tab=doc).
+
+
+
+
 
 

--- a/docs/contract/dataframes.md
+++ b/docs/contract/dataframes.md
@@ -2,6 +2,76 @@
 
 A data frame is a collection of fields, where each field corresponds to a column. Each field, in turn, consists of a collection of values and metadata, such as the data type of those values. 
 
+For example:
+
+```ts
+export interface Field<T = any, V = Vector<T>> {
+  /**
+   * Name of the field (column)
+   */
+  name: string;
+  /**
+   *  Field value type (string, number, and so on)
+   */
+  type: FieldType;
+  /**
+   *  Meta info about how field and how to display it
+   */
+  config: FieldConfig;
+
+  /**
+   * The raw field values
+   * In Grafana 10, this accepts both simple arrays and the Vector interface
+   * In Grafana 11, the Vector interface has been removed
+   */
+  values: V | T[];
+
+  /**
+   * When type === FieldType.Time, this can optionally store
+   * the nanosecond-precison fractions as integers between
+   * 0 and 999999.
+   */
+  nanos?: number[];
+
+  labels?: Labels;
+
+  /**
+   * Cached values with appropriate display and id values
+   */
+  state?: FieldState | null;
+
+  /**
+   * Convert a value for display
+   */
+  display?: DisplayProcessor;
+
+  /**
+   * Get value data links with variables interpolated
+   */
+  getLinks?: (config: ValueLinkConfig) => Array<LinkModel<Field>>;
+}
+```
+
+## Available data frame types
+
+A data frame type consists of a **kind** of data (for example, time series or numeric) and the data **format** (for example, wide). 
+
+The following data frame types are available:
+
+- [Time series](./timeseries.md)
+  - [Wide](./timeseries.md#time-series-wide-format-timeserieswide)
+  - [Long](./timeseries.md#time-series-long-format-timeserieslong-sql-like)
+  - [Multi](./timeseries.md#time-series-multi-format-timeseriesmulti)
+- [Numeric](./numeric.md)
+  - [Wide](./numeric.md#numeric-wide-format-numericwide)
+  - [Multi](./numeric.md#numeric-multi-format-numericmulti)
+  - [Long](./numeric.md#numeric-many-format-numericlong)
+- [Heatmap](./heatmap.md)
+  - [Rows](./heatmap.md#heatmap-rows-heatmaprows)
+  - [Cells](./heatmap.md#heatmap-cells-heatmapcells)
+- [Logs](./logs.md)
+  - [LogLines](./logs.md#loglines)
+
 ## Work with data frames
 
 Refer to [Data frames](https://grafana.com/developers/plugin-tools/key-concepts/data-frames) in the Plugins developer documentation for an overview of data frames. 
@@ -14,15 +84,15 @@ Data frames were introduced in Grafana 7.0, replacing the Time series and Table 
 
 ### Apache Arrow
 
-The data frame structure is inspired by, and uses the [Apache Arrow Project](https://arrow.apache.org/). Javascript Data frames use Arrow Tables as the underlying structure, and the backend Go code serializes its Frames in Arrow Tables for transmission.
+The data frame structure is inspired by and uses the [Apache Arrow Project](https://arrow.apache.org/). JavaScript data frames use Arrow Tables as the underlying structure, and the backend Go code serializes its frames in Arrow Tables for transmission.
 
-### Javascript
+### JavaScript
 
-The JavaScript implementation of data frames is in the [`/src/dataframe` folder](https://github.com/grafana/grafana/tree/main/packages/grafana-data/src/dataframe) and [`/src/types/dataframe.ts`](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/dataFrame.ts) of the [`@grafana/data` package](https://github.com/grafana/grafana/tree/main/packages/grafana-data).
+You can find the JavaScript implementation of data frames in the [`/src/dataframe` folder](https://github.com/grafana/grafana/tree/main/packages/grafana-data/src/dataframe) and [`/src/types/dataframe.ts`](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/dataFrame.ts) of the [`@grafana/data` package](https://github.com/grafana/grafana/tree/main/packages/grafana-data).
 
 ### Go
 
-For documentation on the Go implementation of data frames, refer to the [github.com/grafana/grafana-plugin-sdk-go/data package](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data?tab=doc).
+For documentation on the Go implementation of data frames, refer to the [Grafana SDK Go data package](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data?tab=doc).
 
 
 

--- a/docs/contract/heatmap.md
+++ b/docs/contract/heatmap.md
@@ -1,7 +1,5 @@
 # Heatmap
 
-Status: EARLY Draft/Proposal
-
 Heatmaps are used to show the magnitude of a phenomenon as color in two dimensions. The variation in color may give visual cues about how the phenomenon is clustered or varies over space.
 
 ## Heatmap Rows (HeatmapRows)

--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -1,7 +1,5 @@
 # Logs
 
-Status: EARLY Draft/Proposal
-
 ## LogLines
 
 Version: 0.0

--- a/docs/contract/numeric.md
+++ b/docs/contract/numeric.md
@@ -1,8 +1,8 @@
-# Numeric Kind Formats
+# Numeric data frame kind
 
-Numeric Kinds are generally similar to their corresponding time series type, except that their value is a single number, instead of a series of (time, numeric value). So the value of each metric is a single number like 1, 2.3, or NaN
+Data frames of the kind _numeric_ are generally similar to their corresponding time series type, except that their value is a single number, instead of a series of (time, numeric value). 
 
-This generally corresponds to a prometheus instant vector, or a SQL table with string and number columns and multiple rows.
+In numeric kinds the value of each metric is a single number like 1, 2.3, or NaN. This generally corresponds to a Prometheus instant vector, or to a SQL table with string and number columns and multiple rows.
 
 ## Numeric Wide Format (NumericWide)
 

--- a/docs/contract/timeseries.md
+++ b/docs/contract/timeseries.md
@@ -1,6 +1,8 @@
-# Time Series Kind Formats
+# Time series data frame kind
 
-## Properties Shared by All Time Series Based Formats
+## Common properties
+
+Data frames of the kind _time series_ have the following properties:
 
 - Frames should be sorted by the time column/field in ascending order[^1]
 - The Time field(s):
@@ -70,7 +72,7 @@ The wide format has a set of time series in a single Frame that share the same t
   </tr>
 </table>
 
-It should have the following properties: (Also see Shared Properties):
+It should have the following properties: 
 
 - The first field of type Time is the time index of all the time series.
 - There should be only one Frame with the data type declaration.
@@ -369,4 +371,4 @@ Additional Properties or Considerations:
 
 [^1]: This is because sorting is generally expensive in terms of resources, and is best done by the database behind a datasource in most cases.
 [^2]: I don't believe our current SQL datasources strictly follow this, but some Azure ones do. This was either due to miscommunication about the intent of this format and the upgrade to Grafana 8 and/or lack of understanding about breaking changes, or both.
-[^3]: This transformation happens when queried with "Format As=Time Series". The problem with the transformation happening at this stage of the pipeline is that while it does give the user Time Series for a common Time Series in Table format, it makes it so the "Table View" of the data doesn't like up with SQL returns from their query. **TODO: Define this general concept later, maybe call it "What you see is _NOT_ what you get", "Data Miscommunication", something.** This means we either need to return two things (sort of like exemplars?), or the operation should be moved, or something else.
+[^3]: This transformation happens when queried with "Format As=Time Series". The problem with the transformation happening at this stage of the pipeline is that while it does give the user Time Series for a common Time Series in Table format, it makes it so the "Table View" of the data doesn't like up with SQL returns from their query. 


### PR DESCRIPTION
Moving data frame info from Plugins to Data Portal. Part of https://github.com/grafana/plugin-tools/issues/2184.

Preview - https://grafana-dev.com/developers/dataplane/dataframes#work-with-data-frames