### PR TITLE
docs: add labelTypes to logs dataplane spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 temp/
 .turbo/
+.idea/

--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -35,7 +35,8 @@ Version: 0.0
       `{"hello":"Field", "foo": "Metadata", "bar": "ArrayField" , "baz" : "Field"}`
         - Value should be represented with `Record<string,string>` type in javascript.
     - As of Grafana 12.4 label types are used in Log Details in the Logs Panel to group related labels.
-    - _Note:_ The data source must fulfill the `DataSourceWithLogsLabelTypesSupport` interface, otherwise all labels will display in the default "Fields" category
+    - _Note:_ The data source must fulfill the `DataSourceWithLogsLabelTypesSupport` interface, otherwise all labels
+      will display in the default "Fields" category
 
 Any other field is ignored by logs visualisation.
 
@@ -50,8 +51,8 @@ data.NewFrame(
     data.NewField("body", nil, []string{"message one", "message two", "message three"}),
     data.NewField("severity", nil, []string{"critical", "error", "warning"}),
     data.NewField("id", nil, []string{"xxx-001", "xyz-002", "111-003"}),
-    data.NewField("labels", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"world"}`), []byte(`{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`)}),
-    data.NewField("labelTypes", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"Field"}`), []byte(`{"hello":"Field", "foo": "Metadata", "bar" : "ArrayField", "baz" : "Field"}`)}),
+    data.NewField("labels", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"world"}`), []byte(`{"hello": "world", "foo": 123.45, "bar": ["yellow","red"], "baz": { "name": "alice" }}`)}),
+    data.NewField("labelTypes", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello": "Field"}`), []byte(`{"hello": "Field", "foo": "Metadata", "bar": "ArrayField", "baz": "Field"}`)}),
 )
 ```
 

--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -33,10 +33,9 @@ Version: 0.0
     - This field represents the groupings of the labels.
     - Field type must be json raw message type. Example value: `{}`,
       `{"hello":"Field", "foo": "Metadata", "bar": "ArrayField" , "baz" : "Field"}`
-    -
-        - Value should be represented with `Record<string,any>` type in javascript.
+        - Value should be represented with `Record<string,string>` type in javascript.
     - As of Grafana 12.4 label types are used in Log Details in the Logs Panel to group related labels.
-    - If not provided, all labels will show in a single "Field" category.
+    - _Note:_ The data source must fulfill the `DataSourceWithLogsLabelTypesSupport` interface, otherwise all labels will display in the default "Fields" category
 
 Any other field is ignored by logs visualisation.
 

--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -15,7 +15,7 @@ Version: 0.0
 - **Severity field** - _optional_
     - The first string field with the name `severity` is the severity field.
     - Represents the severity/level of the log line
-    - If no severity field is found, consumers/client will decide the log level. Example: logs panel will try to parse
+    - If no severity field is found, consumers/client will decide the log level. Example: logs visualization will try to parse
       the message field and determine the log level
     - Log level can be one of the values specified in the
       docs [here](https://grafana.com/docs/grafana/latest/explore/logs-integration/)

--- a/docs/contract/logs.md
+++ b/docs/contract/logs.md
@@ -7,24 +7,36 @@ Version: 0.0
 ### Properties and field requirements
 
 - **Time field** - _required_
-  - The first time field with the name `timestamp` is the time field.
-  - it must be non nullable
+    - The first time field with the name `timestamp` is the time field.
+    - it must be non nullable
 - **Body field** - _required_
-  - The first string field with the name `body` is the body field.
-  - it must be non nullable
+    - The first string field with the name `body` is the body field.
+    - it must be non nullable
 - **Severity field** - _optional_
-  - The first string field with the name `severity` is the severity field.
-  - Represents the severity/level of the log line
-  - If no severity field is found, consumers/client will decide the log level. Example: logs panel will try to parse the message field and determine the log level
-  - Log level can be one of the values specified in the docs [here](https://grafana.com/docs/grafana/latest/explore/logs-integration/)
+    - The first string field with the name `severity` is the severity field.
+    - Represents the severity/level of the log line
+    - If no severity field is found, consumers/client will decide the log level. Example: logs panel will try to parse
+      the message field and determine the log level
+    - Log level can be one of the values specified in the
+      docs [here](https://grafana.com/docs/grafana/latest/explore/logs-integration/)
 - **ID field** - _optional_
-  - The first string field with the name `id` is the id field.
-  - Unique identifier of the log line
+    - The first string field with the name `id` is the id field.
+    - Unique identifier of the log line
 - **Labels field** - _optional_
-  - The first field with the name `labels` is the labels field.
-  - This field represents additional information about the log line.
-  - Field type must be json raw message type. Example value: `{}`, `{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`
-    - Value should be represented with `Record<string,any>` type in javascript.
+    - The first field with the name `labels` is the labels field.
+    - This field represents additional information about the log line.
+    - Field type must be json raw message type. Example value: `{}`,
+      `{"hello": "world", "foo": 123.45, "bar": ["yellow","red"], "baz": { "name": "alice" }}`
+        - Value should be represented with `Record<string,any>` type in javascript.
+- **LabelTypes field** - _optional_
+    - The first field with the name `labelTypes` is the label types field.
+    - This field represents the groupings of the labels.
+    - Field type must be json raw message type. Example value: `{}`,
+      `{"hello":"Field", "foo": "Metadata", "bar": "ArrayField" , "baz" : "Field"}`
+    -
+        - Value should be represented with `Record<string,any>` type in javascript.
+    - As of Grafana 12.4 label types are used in Log Details in the Logs Panel to group related labels.
+    - If not provided, all labels will show in a single "Field" category.
 
 Any other field is ignored by logs visualisation.
 
@@ -40,21 +52,23 @@ data.NewFrame(
     data.NewField("severity", nil, []string{"critical", "error", "warning"}),
     data.NewField("id", nil, []string{"xxx-001", "xyz-002", "111-003"}),
     data.NewField("labels", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"world"}`), []byte(`{"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }}`)}),
+    data.NewField("labelTypes", nil, []json.RawMessage{[]byte(`{}`), []byte(`{"hello":"Field"}`), []byte(`{"hello":"Field", "foo": "Metadata", "bar" : "ArrayField", "baz" : "Field"}`)}),
 )
 ```
 
 the same can be represented as
 
-| Name: timestamp <br/> Type: []time.Time | Name: body <br/> Type: []string | Name: severity <br/> Type: []\*string | Name: id <br/> Type: []\*string | Name: labels <br/> Type: []json.RawMessage                                         |
-| --------------------------------------- | ------------------------------- | ------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------- |
-| 2022-02-16 16:50:44.810 +0000 GMT       | message one                     | critical                              | xxx-001                         | {}                                                                                     |
-| 2022-02-16 16:50:47.027 +0000 GMT       | message two                     | error                                 | xyz-002                         | {"hello":"world"}                                                                      |
-| 2022-02-16 16:50:47.027 +0000 GMT       | message three                   | warning                               | 111-003                         | {"hello":"world", "foo": 123.45, "bar" :["yellow","red"], "baz" : { "name": "alice" }} |
+| Name: timestamp <br/> Type: []time.Time | Name: body <br/> Type: []string | Name: severity <br/> Type: []\*string | Name: id <br/> Type: []\*string | Name: labels <br/> Type: []json.RawMessage                                             | Name: labelTypes <br/> Type: []json.RawMessage                                |     
+|-----------------------------------------|---------------------------------|---------------------------------------|---------------------------------|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| 2022-02-16 16:50:44.810 +0000 GMT       | message one                     | critical                              | xxx-001                         | {}                                                                                     | {}                                                                            |
+| 2022-02-16 16:50:47.027 +0000 GMT       | message two                     | error                                 | xyz-002                         | {"hello": "world"}                                                                     | {"hello": "Field"}                                                            | 
+| 2022-02-16 16:50:47.027 +0000 GMT       | message three                   | warning                               | 111-003                         | {"hello": "world", "foo": 123.45, "bar": ["yellow","red"], "baz": { "name": "alice" }} | {"hello":"Field", "foo": "Number Field", "bar": "ArrayField", "baz": "Field"} |
 
 ### Meta data requirements
 
 - Frame type must be set to `FrameTypeLogLines`/`log-lines`
-- Frame meta can optionally specify `preferredVisualisationType:logs` as meta data. Without this property, explore page will be rendering the logs data as table instead in logs view
+- Frame meta can optionally specify `preferredVisualisationType:logs` as metadata. Without this property, explore page
+  will be rendering the logs data as table instead in logs view
 
 ### Invalid cases
 


### PR DESCRIPTION
Adding the `labelTypes` field to the spec.

Related: https://github.com/grafana/grafana/pull/117025