### PR TITLE
chore: disable yarn scripts

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/docusaurus/website/package.json
+++ b/docusaurus/website/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@grafana/dataplane-website",
   "version": "0.7.0",
+  "packageManager": "yarn@1.22.22",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@grafana/dataplane-examples",
+  "packageManager": "yarn@1.22.22",
   "private": true,
   "scripts": {
     "test:backend": "go test -v ./..."

--- a/sdata/package.json
+++ b/sdata/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@grafana/sdata",
+  "packageManager": "yarn@1.22.22",
   "private": true,
   "scripts": {
     "test:backend": "go test -v ./..."


### PR DESCRIPTION
As this is mono repo, defining the packageManager is root package.json is suffice and already defined. This PR additionally define in all the workspace package.json files. Also set `ignore-scripts true` in the root .yarnrc file. ( repo uses yarn@1.22.22 )